### PR TITLE
FIX: fixing the widget load and javascript execution issue

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,8 @@ dependencies:
 
   cupertino_icons: ^1.0.8
   webview_flutter: ^4.10.0
+  path_provider: ^2.1.0
+
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
The culprit for the issue that you were facing for the webkit permission issue was because of the `runJavascript` method , it was being executed while the html page was not fully loaded , so the solution is either to make sure that page loaded successfully so it was moved to `onPageFinished` ,another solution is to create a script tag in the html to run whatever javascript you want hence making sure that the file is loaded by adding an event listener on the DOM content loaded event, also loading the html file as a string is not recommended in webviews that is why i loaded as file and it is in a temp folder , feel free to change this implementation detail, but the idea is to load the widget file as a file not a string

with these changes you will be able to load the changelog page icon without any issues , also you can implement another widget that will show whenever you click on the what's new button or an embed widget that will show directly 

Hope this helps , feel free to ask me anything about the implementation 
Thanks 🙌 